### PR TITLE
Added getCurrentConfigurations plugin method

### DIFF
--- a/ios/Plugin/WidgetsBridgePluginPlugin.m
+++ b/ios/Plugin/WidgetsBridgePluginPlugin.m
@@ -9,4 +9,5 @@ CAP_PLUGIN(WidgetsBridgePluginPlugin, "WidgetsBridgePlugin",
            CAP_PLUGIN_METHOD(removeItem, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(reloadAllTimelines, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(reloadTimelines, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getCurrentConfigurations, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/WidgetsBridgePluginPlugin.swift
+++ b/ios/Plugin/WidgetsBridgePluginPlugin.swift
@@ -95,4 +95,27 @@ public class WidgetsBridgePluginPlugin: CAPPlugin {
         }
     }
     
+    @objc func getCurrentConfigurations(_ call: CAPPluginCall) {
+        if #available(iOS 14.0, *) {
+            WidgetCenter.shared.getCurrentConfigurations { result in
+                guard case .success(let widgets) = result else {
+                    call.reject("Could not get current configurations")
+                    return
+                }
+                
+                call.resolve(["results": widgets.map { widget in
+                    [
+                        "family": widget.family.description,
+                        "kind": widget.kind,
+                        "configuration": [
+                            "description": widget.configuration?.description
+                        ]
+                    ]
+                }])
+            }
+        } else {
+            call.unavailable("Not available in iOS 13 or earlier.")
+        }
+    }
+    
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -43,6 +43,14 @@ export interface WidgetsBridgePluginPlugin {
    * @returns {Promise<DataResults<boolean>>} Promise represents the operation results
    */
   reloadTimelines(options: TimelinesOptions): Promise<DataResults<boolean>>;
+  
+  /**
+   * Get current widget configurations
+   *
+   * @since 0.0.1
+   * @returns {Promise<DataResults<any>>} Promise represents the operation results
+   */
+  getCurrentConfigurations(): Promise<DataResults<any>>;
 }
 
 export interface UserDefaultsOptions{


### PR DESCRIPTION
This plugin is very useful for working with iOS widgets in capacitor. One thing I think is missing which would be useful is to be able to getCurrentConfigurations for the installed widgets.